### PR TITLE
Include LWJGL3's error message in MC-297 check

### DIFF
--- a/config/modules/ModuleCrash.json
+++ b/config/modules/ModuleCrash.json
@@ -33,6 +33,11 @@
           "duplicates": "MC-297"
         },
         {
+          "head": "WGL: The driver does not appear to support OpenGL",
+          "resolveAs": "Duplicate",
+          "duplicates": "MC-297"
+        },
+        {
           "head": "failed to create a child event loop",
           "resolveAs": "Duplicate",
           "duplicates": "MC-34749"


### PR DESCRIPTION
LWJGL 3 changed the error message when OpenGL couldn't be found.  The new message is `java.lang.IllegalStateException: GLFW error 65542: WGL: The driver does not appear to support OpenGL`.

This specific message is generated by GLFW [here](https://github.com/glfw/glfw/blob/2c1fc13ee4094f579981a5e18a06dccb0a009e68/src/wgl_context.c#L209-L210), and the constant `GLFW_API_UNAVAILABLE` is defined [here](https://github.com/glfw/glfw/blob/7ef34eb06de54dd9186d3d21a401b2ef819b59e7/include/GLFW/glfw3.h#L683-L698) as 0x10006 = `65542`.  I've chosen to look only at the error message because [`GLFW_API_UNAVAILABLE` is used elsewhere](https://github.com/glfw/glfw/search?q=GLFW_API_UNAVAILABLE&unscoped_q=GLFW_API_UNAVAILABLE) but it might make sense to test for `GLFW error 65542` instead if all other cases also indicate MC-297.  As far as I can tell, "`WGL: The driver does not appear to support OpenGL`" isn't translated so it's fine to use that directly, though.

Relevant tickets:

* [MC-297](https://bugs.mojang.com/browse/MC-297 '[MC-297] "Pixel Format Not Accelerated" / "Could not init GLX" / Bad video card drivers')
* [MC-128302](https://bugs.mojang.com/browse/MC-128302 'GLFW error 65542: WGL: The driver does not appear to support OpenGL')