### PR TITLE
Fix #15 (Piracy terms check seems to malfunction)

### DIFF
--- a/checks/ModulePiracy.js
+++ b/checks/ModulePiracy.js
@@ -3,11 +3,16 @@
 var Module = require('../lib/module.class.js');
 var log = require('../util/logger');
 
+// from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+function escapeRegExp(string) {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}
+
 const PIRACYSIGNATURES = ['Minecraft Launcher null', 'Bootstrap 0', 'Launcher: 1.0.10  (bootstrap 4)', 'Launcher: 1.0.10  (bootstrap 5)',
     'Launcher 3.0.0', 'Launcher: 3.1.0', 'Launcher: 3.1.1', 'Launcher: 3.1.4', '1.0.8', 'uuid sessionId',
     'auth_access_token', 'windows-${arch}', 'keicraft', 'keinett', 'nodus', 'iridium', 'mcdonalds', 'uranium', 'nova',
-    'divinity', 'gemini', 'mineshafter', 'Team-NeO', 'DarkLBP', 'Launcher X', 'PHVL'];
-const PIRACYSIGNATURES_descsum = ['mcleaks', 'mcmarket'];
+    'divinity', 'gemini', 'mineshafter', 'Team-NeO', 'DarkLBP', 'Launcher X', 'PHVL'].map(escapeRegExp);
+const PIRACYSIGNATURES_descsum = ['mcleaks', 'mcmarket'].map(escapeRegExp);
 const PIRACYREGEX = new RegExp(PIRACYSIGNATURES.join('|'), 'i');
 const PIRACYREGEX_descsum = new RegExp(PIRACYSIGNATURES_descsum.join('|'), 'i');
 


### PR DESCRIPTION
Attempt to fix #15. The strings are escaped upon initialization before being added to the regex. Previously all periods were interpreted as "any character". That's obviously not what we want.

The escapeRegExp function could or should probably be moved somewhere else, but I guess for now it should be fine where it is.