### PR TITLE
Add tlauncher to pirated clients

### DIFF
--- a/checks/ModulePiracy.js
+++ b/checks/ModulePiracy.js
@@ -9,9 +9,9 @@ function escapeRegExp(string) {
 }
 
 const PIRACYSIGNATURES = ['Minecraft Launcher null', 'Bootstrap 0', 'Launcher: 1.0.10  (bootstrap 4)', 'Launcher: 1.0.10  (bootstrap 5)',
-    'Launcher 3.0.0', 'Launcher: 3.1.0', 'Launcher: 3.1.1', 'Launcher: 3.1.4', '1.0.8', 'uuid sessionId',
-    'auth_access_token', 'windows-${arch}', 'keicraft', 'keinett', 'nodus', 'iridium', 'mcdonalds', 'uranium', 'nova',
-    'divinity', 'gemini', 'mineshafter', 'Team-NeO', 'DarkLBP', 'Launcher X', 'PHVL', 'Pre-Launcher v6', 'LauncherFEnix', 'TLauncher'].map(escapeRegExp);
+    'Launcher 3.0.0', 'Launcher: 3.1.0', 'Launcher: 3.1.1', 'Launcher: 3.1.4', '1.0.8', 'uuid sessionId', 'auth_access_token',
+    'windows-${arch}', 'keicraft', 'keinett', 'nodus', 'iridium', 'mcdonalds', 'uranium', 'nova', 'divinity', 'gemini',
+    'mineshafter', 'Team-NeO', 'DarkLBP', 'Launcher X', 'PHVL', 'Pre-Launcher v6', 'LauncherFEnix', 'TLauncher'].map(escapeRegExp);
 const PIRACYSIGNATURES_descsum = ['mcleaks', 'mcmarket'].map(escapeRegExp);
 const PIRACYREGEX = new RegExp(PIRACYSIGNATURES.join('|'), 'i');
 const PIRACYREGEX_descsum = new RegExp(PIRACYSIGNATURES_descsum.join('|'), 'i');

--- a/checks/ModulePiracy.js
+++ b/checks/ModulePiracy.js
@@ -11,7 +11,7 @@ function escapeRegExp(string) {
 const PIRACYSIGNATURES = ['Minecraft Launcher null', 'Bootstrap 0', 'Launcher: 1.0.10  (bootstrap 4)', 'Launcher: 1.0.10  (bootstrap 5)',
     'Launcher 3.0.0', 'Launcher: 3.1.0', 'Launcher: 3.1.1', 'Launcher: 3.1.4', '1.0.8', 'uuid sessionId',
     'auth_access_token', 'windows-${arch}', 'keicraft', 'keinett', 'nodus', 'iridium', 'mcdonalds', 'uranium', 'nova',
-    'divinity', 'gemini', 'mineshafter', 'Team-NeO', 'DarkLBP', 'Launcher X', 'PHVL', 'Pre-Launcher v6', 'LauncherFEnix'].map(escapeRegExp);
+    'divinity', 'gemini', 'mineshafter', 'Team-NeO', 'DarkLBP', 'Launcher X', 'PHVL', 'Pre-Launcher v6', 'LauncherFEnix', 'TLauncher'].map(escapeRegExp);
 const PIRACYSIGNATURES_descsum = ['mcleaks', 'mcmarket'].map(escapeRegExp);
 const PIRACYREGEX = new RegExp(PIRACYSIGNATURES.join('|'), 'i');
 const PIRACYREGEX_descsum = new RegExp(PIRACYSIGNATURES_descsum.join('|'), 'i');


### PR DESCRIPTION
Tlauncher allows you to login with their own servers instead of Mojang, allowing pirated users to play